### PR TITLE
Fix Expo route names and env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+SUPABASE_URL=https://your-supabase-project.supabase.co
+SUPABASE_ANON_KEY=your-anon-key
+EXPO_PUBLIC_BACKEND_API_URL=http://localhost:3000

--- a/README-chemfetch-mobile.md
+++ b/README-chemfetch-mobile.md
@@ -44,9 +44,8 @@
 ```
 chemfetch-mobile/
 ├── app/                         # Expo Router-based screens
-│   ├── index.tsx                # Scan entry point (redirects to scanner)
-│   ├── home.tsx                 # Home screen
-│   ├── scanner.tsx              # Barcode scanning screen
+│   ├── index.tsx                # Home screen
+│   ├── barcode.tsx              # Barcode scanning screen
 │   ├── confirm.tsx              # OCR confirmation screen
 │   ├── results.tsx              # Product & SDS lookup results
 │   └── sds-viewer.tsx           # SDS PDF viewer screen
@@ -93,7 +92,7 @@ Create a `.env` file at project root:
 ```env
 SUPABASE_URL=https://your-supabase-project.supabase.co
 SUPABASE_ANON_KEY=your-anon-key
-BACKEND_API_URL=http://<your-backend-host>:3000
+EXPO_PUBLIC_BACKEND_API_URL=http://<your-backend-host>:3000
 ```
 
 ### 4. Running the App

--- a/README.md
+++ b/README.md
@@ -44,9 +44,8 @@
 ```
 chemfetch-mobile/
 ├── app/                         # Expo Router-based screens
-│   ├── index.tsx                # Scan entry point (redirects to scanner)
-│   ├── home.tsx                 # Home screen
-│   ├── scanner.tsx              # Barcode scanning screen
+│   ├── index.tsx                # Home screen
+│   ├── barcode.tsx              # Barcode scanning screen
 │   ├── confirm.tsx              # OCR confirmation screen
 │   ├── results.tsx              # Product & SDS lookup results
 │   └── sds-viewer.tsx           # SDS PDF viewer screen
@@ -93,7 +92,7 @@ Create a `.env` file at project root:
 ```env
 SUPABASE_URL=https://your-supabase-project.supabase.co
 SUPABASE_ANON_KEY=your-anon-key
-BACKEND_API_URL=http://<your-backend-host>:3000
+EXPO_PUBLIC_BACKEND_API_URL=http://<your-backend-host>:3000
 ```
 
 ### 4. Running the App

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -21,31 +21,17 @@ export default function TabLayout() {
       }}
     >
       <Tabs.Screen
-        name="home"
+        name="index"
         options={{
           title: 'Home',
           tabBarIcon: ({ color }) => <TabBarIcon name="home" color={color} />,
         }}
       />
       <Tabs.Screen
-        name="scanner"
+        name="barcode"
         options={{
           title: 'Scan',
           tabBarIcon: ({ color }) => <TabBarIcon name="camera" color={color} />,
-        }}
-      />
-      <Tabs.Screen
-        name="about"
-        options={{
-          title: 'About',
-          tabBarIcon: ({ color }) => <TabBarIcon name="info-circle" color={color} />,
-        }}
-      />
-      <Tabs.Screen
-        name="settings"
-        options={{
-          title: 'Settings',
-          tabBarIcon: ({ color }) => <TabBarIcon name="cog" color={color} />,
         }}
       />
 

--- a/app/_layout_old.tsx
+++ b/app/_layout_old.tsx
@@ -21,31 +21,17 @@ export default function TabLayout() {
       }}
     >
       <Tabs.Screen
-        name="home"
+        name="index"
         options={{
           title: 'Home',
           tabBarIcon: ({ color }) => <TabBarIcon name="home" color={color} />,
         }}
       />
       <Tabs.Screen
-        name="scanner"
+        name="barcode"
         options={{
           title: 'Scan',
           tabBarIcon: ({ color }) => <TabBarIcon name="camera" color={color} />,
-        }}
-      />
-      <Tabs.Screen
-        name="about"
-        options={{
-          title: 'About',
-          tabBarIcon: ({ color }) => <TabBarIcon name="info-circle" color={color} />,
-        }}
-      />
-      <Tabs.Screen
-        name="settings"
-        options={{
-          title: 'Settings',
-          tabBarIcon: ({ color }) => <TabBarIcon name="cog" color={color} />,
         }}
       />
 


### PR DESCRIPTION
## Summary
- update tab layout to use existing routes
- add `.env.example` with public backend variable
- update project structure docs
- adjust README env var instructions

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688a9396eef0832fa520e7a3bdc46c17