### PR TITLE
Fix scanning navigation and env warnings

### DIFF
--- a/app.json
+++ b/app.json
@@ -34,7 +34,7 @@
           "backgroundColor": "#ffffff"
         }
       ],
-      "expo-barcode-scanner",
+      "expo-camera",
       "expo-web-browser"
     ],
     "experiments": {

--- a/app/barcode.tsx
+++ b/app/barcode.tsx
@@ -38,10 +38,11 @@ export default function BarcodeScanner() {
         Alert.alert('Scan Complete', `Type: ${type}\nData: ${data}`, [
             {
                 text: 'View Results',
-                onPress: () => router.push({
-                    pathname: './results' as const,
-                    params: { code: data },
-                }),
+                onPress: () =>
+                    router.push({
+                        pathname: '/results' as const,
+                        params: { code: data },
+                    }),
             },
             {
                 text: 'Scan Again',

--- a/app/confirm.tsx
+++ b/app/confirm.tsx
@@ -2,6 +2,7 @@
 import { CropOverlay } from '@/components/CropOverlay';
 import { SizePromptModal } from '@/components/SizePromptModal';
 import { CropInfo, runOcr } from '@/lib/ocr';
+import { BACKEND_API_URL } from '@/lib/constants';
 import { useConfirmStore } from '@/lib/store';
 import { CameraView, useCameraPermissions } from 'expo-camera';
 import { useLocalSearchParams, useRouter } from 'expo-router';
@@ -92,7 +93,7 @@ export default function Confirm() {
 
   const saveItem = async (finalName: string, finalSize: string) => {
     try {
-      await fetch(`${process.env.EXPO_PUBLIC_BACKEND_API_URL}/confirm`, {
+      await fetch(`${BACKEND_API_URL}/confirm`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ code, name: finalName, size: finalSize }),

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,7 +1,7 @@
 // lib/constants.ts
 
 // Make sure you have EXPO_PUBLIC_BACKEND_API_URL in your .env file
-export const BACKEND_API_URL = process.env.EXPO_PUBLIC_BACKEND_API_URL!;
+export const BACKEND_API_URL = process.env.EXPO_PUBLIC_BACKEND_API_URL;
 
 if (!BACKEND_API_URL) {
   console.warn('⚠️ Missing EXPO_PUBLIC_BACKEND_API_URL in .env');


### PR DESCRIPTION
## Summary
- ensure navigation to results uses absolute route
- use constant for backend URL and avoid non-null assertion
- update confirm screen to use new constant
- replace barcode scanner plugin with expo-camera

## Testing
- `npx tsc --noEmit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688a97613144832f99f16be0071a9ca2