### PR TITLE
Fix hidden camera preview

### DIFF
--- a/app/barcode.tsx
+++ b/app/barcode.tsx
@@ -6,7 +6,7 @@ import {
 } from 'expo-camera';
 import { useRouter } from 'expo-router';
 import { useEffect, useState } from 'react';
-import { Alert, Pressable, Text, Vibration, View } from 'react-native';
+import { Alert, Pressable, Text, Vibration, View, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function BarcodeScanner() {
@@ -58,7 +58,7 @@ const handleBarcodeScanned = ({ type, data }: BarcodeScanningResult) => {
     <SafeAreaView className="flex-1 bg-black">
       <View className="flex-1">
         <CameraView
-          className="flex-1"
+          style={StyleSheet.absoluteFill}
           onBarcodeScanned={scanned ? undefined : handleBarcodeScanned}
           barcodeScannerSettings={{ barcodeTypes: ['ean8', 'ean13'] }}
         />

--- a/app/confirm.tsx
+++ b/app/confirm.tsx
@@ -171,7 +171,7 @@ const saveItem = async (finalName: string, finalSize: string) => {
         ) : (
           <CameraView
             ref={cameraRef}
-            className="flex-1"
+            style={{ flex: 1 }}
             onLayout={(e) => {
               const { width, height } = e.nativeEvent.layout;
               setImageLayout({ width, height });


### PR DESCRIPTION
## Summary
- render camera in barcode scanner with a regular style prop
- do the same on the confirm photo step

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688be3ec0c00832f94f2074aaa4762f4