### PR TITLE
Implement OCR step after barcode scan

### DIFF
--- a/app/barcode.tsx
+++ b/app/barcode.tsx
@@ -6,7 +6,7 @@ import {
 } from 'expo-camera';
 import { useRouter } from 'expo-router';
 import { useEffect, useState } from 'react';
-import { Alert, Pressable, Text, Vibration, View, StyleSheet } from 'react-native';
+import { Pressable, Text, Vibration, View, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function BarcodeScanner() {
@@ -36,22 +36,20 @@ const handleBarcodeScanned = ({ type, data }: BarcodeScanningResult) => {
     .then((res) => res.json())
     .then((json) => {
       console.log('✅ Response from backend:', json);
+      const prod = json.product ?? json;
+      router.push({
+        pathname: '/confirm',
+        params: {
+          code: data,
+          name: prod.product_name || prod.name || '',
+          size: prod.contents_size_weight || prod.size || '',
+        },
+      });
     })
     .catch((err) => {
       console.error('❌ Backend error:', err);
+      router.push({ pathname: '/confirm', params: { code: data } });
     });
-
-  Alert.alert('Scan Complete', `Type: ${type}\nData: ${data}`, [
-    {
-      text: 'View Results',
-      onPress: () =>
-        router.push({
-          pathname: '/results' as const,
-          params: { code: data },
-        }),
-    },
-    { text: 'Scan Again', onPress: () => setScanned(false) },
-  ]);
 };
 
   return (


### PR DESCRIPTION
## Summary
- trigger the confirmation/OCR capture flow directly after a barcode scan

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688c7c0ea7c8832fba43b5c75a0a1d49