### PR TITLE
Improve barcode loading screen and add OCR retake option

### DIFF
--- a/app/barcode.tsx
+++ b/app/barcode.tsx
@@ -9,6 +9,7 @@ import { useRouter } from 'expo-router';
 import { useEffect, useState } from 'react';
 import {
   ActivityIndicator,
+  Image,
   Pressable,
   StyleSheet,
   Text,
@@ -67,38 +68,44 @@ const handleBarcodeScanned = ({ type, data }: BarcodeScanningResult) => {
 
   return (
     <SafeAreaView className="flex-1 bg-black">
-      <View className="flex-1">
-        {isFocused && (
-          <CameraView
-            style={StyleSheet.absoluteFill}
-            onBarcodeScanned={scanned ? undefined : handleBarcodeScanned}
-            barcodeScannerSettings={{ barcodeTypes: ['ean8', 'ean13'] }}
+      {loading ? (
+        <View className="flex-1 justify-center items-center bg-black">
+          <Image
+            source={require('@/assets/images/splash-icon.png')}
+            className="w-32 h-32 mb-4"
           />
-        )}
-      </View>
-
-      <View className="absolute inset-0 justify-center items-center">
-        <View className="w-[70%] h-48 border-4 border-white rounded-xl bg-white/10 justify-center items-center">
-          <Text className="text-white font-bold text-base text-center px-4">
-            Align barcode here
-          </Text>
-        </View>
-      </View>
-
-      {scanned && (
-        <Pressable
-          className="absolute bottom-10 self-center bg-primary py-3 px-6 rounded-lg"
-          onPress={() => setScanned(false)}
-        >
-          <Text className="text-white text-base font-bold">Scan Again</Text>
-        </Pressable>
-      )}
-
-      {loading && (
-        <View className="absolute inset-0 bg-black/40 justify-center items-center">
           <ActivityIndicator size="large" color="#fff" />
           <Text className="text-white mt-2">Searching...</Text>
         </View>
+      ) : (
+        <>
+          <View className="flex-1">
+            {isFocused && (
+              <CameraView
+                style={StyleSheet.absoluteFill}
+                onBarcodeScanned={scanned ? undefined : handleBarcodeScanned}
+                barcodeScannerSettings={{ barcodeTypes: ['ean8', 'ean13'] }}
+              />
+            )}
+          </View>
+
+          <View className="absolute inset-0 justify-center items-center">
+            <View className="w-[70%] h-48 border-4 border-white rounded-xl bg-white/10 justify-center items-center">
+              <Text className="text-white font-bold text-base text-center px-4">
+                Align barcode here
+              </Text>
+            </View>
+          </View>
+
+          {scanned && (
+            <Pressable
+              className="absolute bottom-10 self-center bg-primary py-3 px-6 rounded-lg"
+              onPress={() => setScanned(false)}
+            >
+              <Text className="text-white text-base font-bold">Scan Again</Text>
+            </Pressable>
+          )}
+        </>
       )}
     </SafeAreaView>
   );

--- a/app/confirm.tsx
+++ b/app/confirm.tsx
@@ -393,7 +393,24 @@ export default function Confirm() {
           {ocrLoading ? (
             <ActivityIndicator size="large" />
           ) : (
-            <Button title="Run OCR" onPress={handleOcr} />
+            <View className="flex-row space-x-4">
+              <Pressable
+                className="bg-gray-200 py-3 px-6 rounded-lg"
+                onPress={() => {
+                  clearPhoto();
+                  resetCrop();
+                  setStep('photo');
+                }}
+              >
+                <Text className="text-dark-100 font-bold">Retake</Text>
+              </Pressable>
+              <Pressable
+                className="bg-primary py-3 px-6 rounded-lg"
+                onPress={handleOcr}
+              >
+                <Text className="text-white font-bold">Run OCR</Text>
+              </Pressable>
+            </View>
           )}
         </View>
       </View>


### PR DESCRIPTION
## Summary
- show ChemFetch logo and hide camera while barcode search is loading
- allow retaking photo before running OCR in the crop step

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c7257ef14832f9dd8773e1d566fd5