### PR TITLE
Add OCR capture instructions and reset camera state

### DIFF
--- a/app/barcode.tsx
+++ b/app/barcode.tsx
@@ -51,7 +51,7 @@ const handleBarcodeScanned = ({ type, data }: BarcodeScanningResult) => {
       console.log('✅ Response from backend:', json);
       const prod = json.product ?? json;
       router.replace({
-        pathname: '/confirm',
+        pathname: '/ocr-info',
         params: {
           code: data,
           name: prod.product_name || prod.name || '',
@@ -61,7 +61,7 @@ const handleBarcodeScanned = ({ type, data }: BarcodeScanningResult) => {
     })
     .catch((err) => {
       console.error('❌ Backend error:', err);
-      router.replace({ pathname: '/confirm', params: { code: data } });
+      router.replace({ pathname: '/ocr-info', params: { code: data } });
     })
     .finally(() => setLoading(false));
 };

--- a/app/confirm.tsx
+++ b/app/confirm.tsx
@@ -98,6 +98,21 @@ export default function Confirm() {
   const clearPhoto = useConfirmStore((s) => s.clearPhoto);
   const resetCrop = useConfirmStore((s) => s.resetCrop);
 
+  // Clear previous photo and reset state when a new code is provided
+  useEffect(() => {
+    clearPhoto();
+    resetCrop();
+    setStep(editOnly ? 'pick' : 'photo');
+  }, [code, editOnly, clearPhoto, resetCrop]);
+
+  // Ensure photo is cleared when leaving this screen
+  useEffect(() => {
+    return () => {
+      clearPhoto();
+      resetCrop();
+    };
+  }, [clearPhoto, resetCrop]);
+
   // ───────────────────── permissions & availability ──────────────────
   useEffect(() => {
     if (!editOnly && !permission) requestPermission();
@@ -335,17 +350,24 @@ export default function Confirm() {
         {photo ? (
           <Image source={{ uri: photo.uri }} className="flex-1" resizeMode="cover" />
         ) : (
-          isFocused && cameraAvailable && (
-            <CameraView
-              ref={cameraRef}
-              style={{ flex: 1 }}
-              onLayout={(e: LayoutChangeEvent) => {
-                const { width, height } = e.nativeEvent.layout;
-                setImageLayout({ width, height });
-              }}
-              onCameraReady={() => setCameraReady(true)}
-            />
-          )
+          <>
+            {isFocused && cameraAvailable && (
+              <CameraView
+                ref={cameraRef}
+                style={{ flex: 1 }}
+                onLayout={(e: LayoutChangeEvent) => {
+                  const { width, height } = e.nativeEvent.layout;
+                  setImageLayout({ width, height });
+                }}
+                onCameraReady={() => setCameraReady(true)}
+              />
+            )}
+            <View className="absolute inset-0 justify-center items-center pointer-events-none">
+              <View className="w-[90%] h-48 border-4 border-white rounded-xl bg-white/10 relative">
+                <View className="absolute top-1/2 left-0 right-0 h-0.5 bg-white" />
+              </View>
+            </View>
+          </>
         )}
         <View className="absolute bottom-6 left-0 right-0 items-center">
           <Pressable

--- a/app/ocr-info.tsx
+++ b/app/ocr-info.tsx
@@ -1,0 +1,32 @@
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { View, Text, Pressable } from 'react-native';
+
+export default function OcrInfoScreen() {
+  const router = useRouter();
+  const { code = '', name = '', size = '' } = useLocalSearchParams<{
+    code: string;
+    name: string;
+    size: string;
+  }>();
+
+  return (
+    <View className="flex-1 bg-white p-6 justify-center">
+      <Text className="text-lg text-center mb-4">
+        Position the product name within the frame and align it with the
+        horizontal line on the next screen. Make sure the text is clear and
+        readable.
+      </Text>
+      <Pressable
+        className="bg-primary py-3 px-6 rounded-lg self-center"
+        onPress={() =>
+          router.replace({
+            pathname: '/confirm',
+            params: { code, name, size },
+          })
+        }
+      >
+        <Text className="text-white font-bold text-base">Next</Text>
+      </Pressable>
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- Display a guidance screen before the OCR capture step with instructions and Next button
- Navigate from barcode scan to the new instructions screen
- Reset photo state on each scan and add horizontal guideline overlay to capture view

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c768326c8832f9ecd558820b1b461